### PR TITLE
Add `jupyterhub-singleuser` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd -m -s /bin/bash -N -u 1000 jovyan && \
 RUN /bin/bash -c "source activate pyhc-all && \
     python -c 'import wmm2015' && \
     python -c 'import wmm2020'" && \
-    pythom -m pip install --no-cache jupyterhub
+    python -m pip install --no-cache jupyterhub
 
 # Change ownership of the wmm2015 and wmm2020 package directories
 RUN chown -R jovyan:users /opt/conda/envs/pyhc-all/lib/python3.10/site-packages/wmm2015 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ RUN useradd -m -s /bin/bash -N -u 1000 jovyan && \
     chown jovyan:users /home/jovyan/import-test.ipynb && \
     chown jovyan:users /home/jovyan/unit-tests.ipynb
     
-
 # Pre-build the wmm2015 and wmm2020 packages using Bash shell
+# Install jupyterhub package so the image would work on authenticated binderhubs
 RUN /bin/bash -c "source activate pyhc-all && \
     python -c 'import wmm2015' && \
-    python -c 'import wmm2020'"
+    python -c 'import wmm2020'" && \
+    pythom -m pip install --no-cache jupyterhub
 
 # Change ownership of the wmm2015 and wmm2020 package directories
 RUN chown -R jovyan:users /opt/conda/envs/pyhc-all/lib/python3.10/site-packages/wmm2015 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,14 @@ RUN useradd -m -s /bin/bash -N -u 1000 jovyan && \
     chown jovyan:users /home/jovyan/unit-tests.ipynb
     
 # Pre-build the wmm2015 and wmm2020 packages using Bash shell
-# Install jupyterhub package so the image would work on authenticated binderhubs
-# TODO: Could use this conda package (https://anaconda.org/conda-forge/jupyterhub-singleuser/) instead of instlling from pip
 RUN /bin/bash -c "source activate pyhc-all && \
     python -c 'import wmm2015' && \
     python -c 'import wmm2020'" && \
     python -m pip install --no-cache jupyterhub
+
+# Install jupyterhub package so the image would work on authenticated binderhubs
+# Could also be added to the environment.yml file instead
+RUN conda install -c conda-forge -n pyhc-all -y jupyterhub-singleuser
 
 # Change ownership of the wmm2015 and wmm2020 package directories
 RUN chown -R jovyan:users /opt/conda/envs/pyhc-all/lib/python3.10/site-packages/wmm2015 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN useradd -m -s /bin/bash -N -u 1000 jovyan && \
     
 # Pre-build the wmm2015 and wmm2020 packages using Bash shell
 # Install jupyterhub package so the image would work on authenticated binderhubs
+# TODO: Could use this conda package (https://anaconda.org/conda-forge/jupyterhub-singleuser/) instead of instlling from pip
 RUN /bin/bash -c "source activate pyhc-all && \
     python -c 'import wmm2015' && \
     python -c 'import wmm2020'" && \


### PR DESCRIPTION
This is required for the image to launch on authenticated binder installations